### PR TITLE
fix: Step5 SSR 캐시 전략과 태그 캐시 무효화 반영

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -142,6 +142,17 @@ function isDuplicateSourceError(error: unknown): boolean {
   return error.message.includes("sources.url");
 }
 
+function revalidatePostRelatedPaths(slug: string, tags: string[]) {
+  const paths = new Set<string>(["/", "/posts", `/posts/${slug}`]);
+  for (const tag of tags) {
+    paths.add(`/tags/${encodeURIComponent(tag)}`);
+  }
+
+  for (const path of paths) {
+    revalidatePath(path);
+  }
+}
+
 export const dynamic = "force-dynamic";
 
 export async function GET() {
@@ -274,9 +285,7 @@ export async function POST(request: Request) {
       return { postId };
     })();
 
-    revalidatePath("/");
-    revalidatePath("/posts");
-    revalidatePath(`/posts/${slug}`);
+    revalidatePostRelatedPaths(slug, tags);
 
     return NextResponse.json({ id: created.postId, slug }, { status: 201 });
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,8 +73,6 @@ function loadLatestPublishedPosts(limit = 10): PostCardData[] {
   return rows.map(toPostCardData);
 }
 
-export const dynamic = "force-dynamic";
-
 export default function Home() {
   const posts = loadLatestPublishedPosts(10);
 

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -76,8 +76,6 @@ function createCanonicalUrl(slug: string): string | null {
   return `${base.replace(/\/+$/, "")}/posts/${slug}`;
 }
 
-export const dynamic = "force-dynamic";
-
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -109,8 +109,6 @@ function loadPublishedPosts(page: number, perPage: number) {
   }));
 }
 
-export const dynamic = "force-dynamic";
-
 export default async function PostsPage({ searchParams }: PageProps) {
   const params = await searchParams;
   const requestedPage = parsePositiveInteger(params.page, 1);

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -78,8 +78,6 @@ function loadPostsByTag(tag: string) {
   }));
 }
 
-export const dynamic = "force-dynamic";
-
 export default async function TagPage({ params }: PageProps) {
   const { tag } = await params;
   const decodedTag = decodeURIComponent(tag);


### PR DESCRIPTION
## 관련 이슈
- close: #11

## 작업 내용
- Step5 SSR 페이지(`/`, `/posts`, `/posts/[slug]`, `/tags/[tag]`)의 `force-dynamic` 제거로 캐시 서빙 전략 적용
- `POST /api/posts`에서 글/목록/상세 + 관련 태그 경로를 `revalidatePath` 하도록 보강
- `PATCH /api/posts/[id]`에서 기존 태그와 변경 태그 경로를 모두 무효화하도록 보강
- Playwright 시드 데이터 직접 삽입 후 캐시 반영을 위한 revalidation 트리거 추가

## 테스트
- `npm run test:step5`
- `npm run test:all`

## 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 빌드가 성공하나요? (`npm run build`)
- [x] 관련 문서를 업데이트했나요? (N/A)
- [x] [필수] sanitize 스키마를 변경했다면 XSS/sanitize 회귀 테스트(`npm run test:step4`)를 재실행하고 결과를 PR 본문에 기록했나요? (미변경 시 N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized page rendering configuration to enable more efficient caching strategies, potentially improving page load performance across the application.
  * Consolidated post-related cache revalidation logic to streamline handling of content updates and improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->