### PR TITLE
fix: deploy 워크플로우 heredoc 문법 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,22 +142,22 @@ jobs:
 
           if ! curl -fsS "https://${BLOG_DOMAIN}/api/health" > /dev/null; then
             ssh "${VM_USER}@${VM_HOST}" "bash -s" <<'REMOTE'
-            set -euo pipefail
+set -euo pipefail
 
-            PREVIOUS_RELEASE=""
-            if [ -f /tmp/blog-deploy-state ]; then
-              . /tmp/blog-deploy-state
-            fi
+PREVIOUS_RELEASE=""
+if [ -f /tmp/blog-deploy-state ]; then
+  . /tmp/blog-deploy-state
+fi
 
-            if [ -n "${PREVIOUS_RELEASE}" ]; then
-              sudo ln -sfn "${PREVIOUS_RELEASE}" /opt/blog
-              sudo systemctl restart blog
-              sudo systemctl is-active --quiet blog
-            else
-              echo "No previous release available for rollback."
-              exit 1
-            fi
-            REMOTE
+if [ -n "${PREVIOUS_RELEASE}" ]; then
+  sudo ln -sfn "${PREVIOUS_RELEASE}" /opt/blog
+  sudo systemctl restart blog
+  sudo systemctl is-active --quiet blog
+else
+  echo "No previous release available for rollback."
+  exit 1
+fi
+REMOTE
 
             exit 1
           fi


### PR DESCRIPTION
## 관련 이슈
- follow-up: #15

## 작업 내용
- deploy 워크플로우의 health-check rollback 단계에서 heredoc 종료 토큰 들여쓰기 오류 수정
- GitHub Actions bash 파싱 에러() 해결

## 테스트
- node scripts/test-step-6.mjs --check-workflow-policy

## 비고
- 기존 PR #16 머지 이후 발견된 후속 수정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted deployment health-check rollback script for improved readability. No functional changes to deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->